### PR TITLE
feat: add --k8s-handles flag to generate Kubernetes manifests for Ima…

### DIFF
--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -62,6 +62,9 @@ Flag                | Required | Default | Description
 *--network*         | No       | 'default'   | VPC network used by the GCE resources used for creating the disk image.
 *--subnet*          | No       | 'default'   | Subnet used by the GCE resources used for creating the disk image.
 *--service-account* | No       | 'default'   | Service Account email assigned to the GCE instance used for creating the disk image.
+*--k8s-manifests-filepath* | No  | nil     | Specifies the file path where the tool will save the generated Kubernetes VolumeSnapshot and VolumeSnapshotContent manifests.
+*--k8s-namespace*   | No       | 'default' | Specifies the Kubernetes namespace for the generated VolumeSnapshot manifest.
+
 
 ### Go
 
@@ -240,3 +243,22 @@ go run ./cli \
     --image-labels=band=ac-dc \
     --image-labels=theory=ramsey_theory
 ```
+
+### Generate Kubernetes manifests derived from the disk image
+
+Use the `--k8s-manifests-filepath` flag to specify a file path where the tool will save the generated Kubernetes `VolumeSnapshot` and `VolumeSnapshotContent` manifests. You can also specify a custom namespace with the `--k8s-namespace` flag:
+
+```shell
+go run ./cli \
+    --project-name=my-gke-project \
+    --image-name=my-secondary-disk-image \
+    --zone=us-central1-c \
+    --gcs-path=gs://my-gke-project-logs \
+    --disk-size-gb=20 \
+    --container-image=docker.io/library/python:3.11.7-slim-bookworm \
+    --container-image=docker.io/library/nginx:1.25.3 \
+    --timeout=30m \
+    --k8s-manifests-filepath=./image_handles.yaml \
+    --k8s-namespace=my-namespace
+```
+

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -40,6 +42,7 @@ func (s *stringSlice) Set(value string) error {
 
 var (
 	gcpResourceNameRegex = regexp.MustCompile("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+	k8sNamespaceRegex    = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 )
 
 func main() {
@@ -63,6 +66,9 @@ func main() {
 	subnet := flag.String("subnet", "default", "subnet to be used by GCE resources used for disk image creation.")
 	storeSnapshotCheckSum := flag.Bool("store-snapshot-checksum", true, "calculate and store checksums of every snapshot directory.")
 	verifyOnly := flag.Bool("verify-only", false, "Only verifies the disk image provided in image-name, and does not generate any image.")
+	k8sManifestsFilepath := flag.String("k8s-manifests-filepath", "", "Specifies the file path where the tool will save the generated Kubernetes VolumeSnapshot and VolumeSnapshotContent manifests.")
+	k8sNamespace := flag.String("k8s-namespace", "default", "Specifies the Kubernetes namespace for the generated VolumeSnapshot manifest.")
+
 	flag.Var(&imageLabels, "image-labels", "labels tagged to the disk image. This flag can be specified multiple times. The accepted format is `--image-labels=key=val`.")
 	flag.Var(&containerImages, "container-image", "container image to include in the disk image. This flag can be specified multiple times")
 	flag.Var(&storageLocations, "storage-location", "The location to store the final image. If left blank, Compute Engine stores your image in the multi-region closest to the image source. This flag can be specified multiple times")
@@ -80,13 +86,31 @@ func main() {
 		log.Panicf("invalid argument, job-name: %v should be less than 50 characters, got: %v", *jobName, len(*jobName))
 	}
 	if !gcpResourceNameRegex.MatchString(*jobName) {
-		log.Panicf("invalid argument, job-name: %v must conform to `^[a-z]([-a-z0-9]*[a-z0-9])?`")
+		log.Panicf("invalid argument, job-name: %v must conform to `^[a-z]([-a-z0-9]*[a-z0-9])?`", *jobName)
+	}
+	if len(*imageName) == 0 || len(*imageName) >= 64 {
+		log.Panicf("invalid argument, image-name: %v should be between 1 and 63 characters, got: %v", *imageName, len(*imageName))
+	}
+	if !gcpResourceNameRegex.MatchString(*imageName) {
+		log.Panicf("invalid argument, image-name: %v must conform to `^[a-z]([-a-z0-9]*[a-z0-9])?`", *imageName)
 	}
 	if len(*imageFamilyName) >= 64 {
 		log.Panicf("invalid argument, image-family-name: %v should be less than 64 characters, got: %v", *imageFamilyName, len(*imageFamilyName))
 	}
 	if !gcpResourceNameRegex.MatchString(*imageFamilyName) {
 		log.Panicf("invalid argument, image-family-name: %v must conform to `^[a-z]([-a-z0-9]*[a-z0-9])?`", *imageFamilyName)
+	}
+	if *k8sManifestsFilepath != "" {
+		parentDir := filepath.Dir(*k8sManifestsFilepath)
+		if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+			log.Panicf("invalid argument, k8s-manifests-filepath parent directory %q does not exist: %v", parentDir, err)
+		}
+		if len(*k8sNamespace) == 0 || len(*k8sNamespace) > 63 {
+			log.Panicf("invalid argument, k8s-namespace: %v should be between 1 and 63 characters, got: %v", *k8sNamespace, len(*k8sNamespace))
+		}
+		if !k8sNamespaceRegex.MatchString(*k8sNamespace) {
+			log.Panicf("invalid argument, k8s-namespace: %v must conform to `^[a-z0-9]([-a-z0-9]*[a-z0-9])?`", *k8sNamespace)
+		}
 	}
 
 	var auth builder.ImagePullAuthMechanism
@@ -121,6 +145,8 @@ func main() {
 		ImagePullAuth:         auth,
 		ImageLabels:           imageLabels,
 		StoreSnapshotCheckSum: *storeSnapshotCheckSum,
+		K8sManifestsFilepath:  *k8sManifestsFilepath,
+		K8sNamespace:          *k8sNamespace,
 	}
 
 	if *verifyOnly {
@@ -135,6 +161,13 @@ func main() {
 		log.Panicf("unable to generate disk image: %v", err)
 	}
 	fmt.Printf("Image has successfully been created at: projects/%s/global/images/%s\n", req.ProjectName, req.ImageName)
+
+	if req.K8sManifestsFilepath != "" {
+		if err := builder.WriteK8sManifests(req); err != nil {
+			log.Panicf("unable to write k8s manifests: %v", err)
+		}
+		fmt.Printf("Kubernetes manifests generated at: %s\n", req.K8sManifestsFilepath)
+	}
 }
 
 // regionForZone returns the region for a given zone (e.g. "us-central1-c" -> "us-central1").

--- a/gke-disk-image-builder/go.mod
+++ b/gke-disk-image-builder/go.mod
@@ -1,7 +1,8 @@
 module github.com/GoogleCloudPlatform/ai-on-gke/gke-disk-image-builder
 
-go 1.21
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.13
 
 require (
 	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -66,6 +67,51 @@ type Request struct {
 	ImageLabels           []string
 	ServiceAccount        string
 	StoreSnapshotCheckSum bool
+	K8sManifestsFilepath  string
+	K8sNamespace          string
+}
+
+// WriteK8sManifests generates the VolumeSnapshot and VolumeSnapshotContent YAML files
+// derived from the GCE Disk Image URI.
+func WriteK8sManifests(req Request) error {
+	if req.K8sManifestsFilepath == "" {
+		return nil
+	}
+
+	parentDir := filepath.Dir(req.K8sManifestsFilepath)
+	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
+		return fmt.Errorf("parent directory %q does not exist: %w", parentDir, err)
+	}
+
+	vscName := fmt.Sprintf("%s-vsc", req.ImageName)
+	vsName := fmt.Sprintf("%s-vs", req.ImageName)
+	// The handle points to the global GCE Disk Image URI.
+	imageURI := fmt.Sprintf("projects/%s/global/images/%s", req.ProjectName, req.ImageName)
+
+	manifest := fmt.Sprintf(`apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: %s
+spec:
+  deletionPolicy: Retain
+  driver: pd.csi.storage.gke.io
+  source:
+    snapshotHandle: %s
+  volumeSnapshotRef:
+    name: %s
+    namespace: %s
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  source:
+    volumeSnapshotContentName: %s
+`, vscName, imageURI, vsName, req.K8sNamespace, vsName, req.K8sNamespace, vscName)
+
+	return os.WriteFile(req.K8sManifestsFilepath, []byte(manifest), 0644)
 }
 
 func buildDiskStartupScript(req Request) (*os.File, error) {

--- a/gke-disk-image-builder/imager_test.go
+++ b/gke-disk-image-builder/imager_test.go
@@ -1,0 +1,80 @@
+package imager
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWriteK8sManifests(t *testing.T) {
+	// Create a temporary file
+	tmpfile, err := os.CreateTemp("", "k8s-manifests-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+	tmpfile.Close()
+
+	req := Request{
+		ImageName:            "test-image",
+		ProjectName:          "test-project",
+		K8sManifestsFilepath: tmpfile.Name(),
+		K8sNamespace:         "test-namespace",
+	}
+
+	err = WriteK8sManifests(req)
+	if err != nil {
+		t.Fatalf("WriteK8sManifests failed: %v", err)
+	}
+
+	// Read the file content
+	content, err := os.ReadFile(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: test-image-vsc
+spec:
+  deletionPolicy: Retain
+  driver: pd.csi.storage.gke.io
+  source:
+    snapshotHandle: projects/test-project/global/images/test-image
+  volumeSnapshotRef:
+    name: test-image-vs
+    namespace: test-namespace
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: test-image-vs
+  namespace: test-namespace
+spec:
+  source:
+    volumeSnapshotContentName: test-image-vsc
+`
+
+	if string(content) != expected {
+		t.Errorf("Unexpected content:\nGot:\n%s\nWant:\n%s", string(content), expected)
+	}
+}
+
+func TestWriteK8sManifests_ParentDirDoesNotExist(t *testing.T) {
+	req := Request{
+		ImageName:            "test-image",
+		ProjectName:          "test-project",
+		K8sManifestsFilepath: "/nonexistent-dir-12345/manifests.yaml",
+	}
+
+	err := WriteK8sManifests(req)
+	if err == nil {
+		t.Fatal("WriteK8sManifests expected error but got nil")
+	}
+
+	expectedErrMsg := "parent directory \"/nonexistent-dir-12345\" does not exist"
+	if !strings.Contains(err.Error(), expectedErrMsg) {
+		t.Errorf("Expected error message containing %q, got %q", expectedErrMsg, err.Error())
+	}
+}


### PR DESCRIPTION
feat: add --k8s-handles flag to generate Kubernetes manifests for Image Boost

This change adds a `--k8s-handles` flag to the disk image builder. When this flag is provided with a file path, the tool will generate a single YAML file containing both `VolumeSnap>

These generated manifests can be applied to a Kubernetes cluster to represent the disk image as a VolumeSnapshot object, allowing it to be referenced by other resources.

Details:
- The `VolumeSnapshotContent` uses the `pd.csi.storage.gke.io` driver and points to the source GCE image.
- Both manifests use `deletionPolicy: Retain` to protect the underlying asset.
- Output is written to the path specified by `--k8s-handles`.


User Journey:
1. Run the tool to build optimized disk images and auto-generate the VolumeSnapshot YAML manifests.
2. Apply the generated YAML manifests to your cluster(s) via `kubectl` to register the disk images natively.
3. Reference the VolumeSnapshot objects via other Kubernetes clients or controllers to attach the pre-built volumes to nodes.

b/508329505