### PR TITLE
Add a RegistryCredentials to --image-pull-auth, a --registry-credentials option, and a --container-image-file option

### DIFF
--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -23,9 +23,13 @@ examples below to understand how this tool work better.
     have access to it (See examples below).
 1.  Compute Engine API must be enabled.
     (https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=$PROJECT_NAME)
-1.  Verify that `$PROJECT_NUMBER-compute@developer.gserviceaccount.com` has
-    `storage.objectCreator` and `storage.objectViewer` permissions to the
-    provided *GCS path* for the logs and startup script.
+1.  The *--gcs-path* flag is optional. If you omit it, the tool falls back to a
+    `$PROJECT_NAME-daisy-bkt` bucket, creating it in the project on first use, so
+    you don't have to provision a bucket yourself.
+1.  If you *do* provide a *--gcs-path*, verify that
+    `$PROJECT_NUMBER-compute@developer.gserviceaccount.com` has
+    `storage.objectCreator` and `storage.objectViewer` permissions to that
+    bucket for the logs and startup script.
     You can run the following command to grant proper permissions for this:
 
     ```shell
@@ -53,11 +57,12 @@ Flag                | Required | Default | Description
 *--image-labels* | No | nil | Labels tagged to the disk image. This flag can be specified multiple times. The accepted format is `--image-labels=key=val`.
 *--job-name*        | No       | secondary-disk-image | Name of the workflow. This name is used to provision some of the intermediate resources (disks, VMs) needed by the workflow. The maximum length is 50 characters
 *--zone*            | Yes      | nil     | Zone where the resources will be used to create the image creator resources
-*--gcs-path*        | Yes      | nil     | GCS path prefix to dump the logs
+*--gcs-path*        | No       | nil     | GCS path prefix to dump the logs and upload the startup script. If omitted, a `<project>-daisy-bkt` bucket is auto-created (or reused) in the project.
 *--container-image* | Yes      | nil     | Container image with tag to include in the disk image. Tag are required for image like `latest` in this example: `docker.io/library/python:latest`. This flag can be specified multiple times
 *--gcp-oauth*       | No       | nil     | Path to GCP service account credential file
 *--disk-size-gb*    | No       | 10      | Size of a disk that will host the unpacked images
-*--image-pull-auth* | No       | 'None'  | Auth mechanism to pull the container image, valid values: [None, ServiceAccountToken]. None means that the images are publically available and no authentication is required to pull them. ServiceAccountToken means the service account oauth token will be used to pull the images. For more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications
+*--image-pull-auth* | No       | 'None'  | Auth mechanism to pull the container image, valid values: [None, ServiceAccountToken, RegistryCredentials]. None means that the images are publically available and no authentication is required to pull them. ServiceAccountToken means the service account oauth token will be used to pull the images. RegistryCredentials means the `user:password` string provided via *--registry-credentials* will be used to pull the images. For more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications
+*--registry-credentials* | No  | nil     | A `user:password` credential passed to `ctr image pull --user` when *--image-pull-auth=RegistryCredentials*. Use this for private registries (Docker Hub, Quay, Harbor, etc.) that do not accept a GCP service account OAuth token. **Note:** this value is embedded in the startup script uploaded to the GCS bucket (either *--gcs-path* or the auto-created `<project>-daisy-bkt`), so restrict access to that bucket.
 *--timeout*         | No       | '20m'   | Default timeout for each step. Must be set to a proper value if the image is large to account for the pull and image creation time step.
 *--network*         | No       | 'default'   | VPC network used by the GCE resources used for creating the disk image.
 *--subnet*          | No       | 'default'   | Subnet used by the GCE resources used for creating the disk image.
@@ -207,6 +212,29 @@ go run ./cli \
     --zone=$ZONE \
     --gcs-path=gs://$GCS_PATH/ \
     --image-pull-auth=ServiceAccountToken \
+    --container-image=$CONTAINER_IMAGE_FROM_PRIVATE_REGISTRY
+```
+
+### Pull an image from a private registry with a username/password
+
+For private registries that do not accept a GCP service account OAuth token
+(e.g. Docker Hub, Quay, a self-hosted Harbor), provide a static `user:password`
+credential. It is passed verbatim to `ctr image pull --user`.
+
+**Note:** the credential is embedded in the startup script that the tool uploads
+to the GCS bucket (either **--gcs-path** or, if omitted, the auto-created
+`<project>-daisy-bkt`). Restrict access to that bucket accordingly, and prefer a
+scoped, read-only token over a long-lived password.
+
+`--gcs-path` is omitted below to show that no bucket needs to be configured:
+
+```shell
+go run ./cli \
+    --project-name=$PROJECT_NAME \
+    --image-name=$IMAGE_NAME \
+    --zone=$ZONE \
+    --image-pull-auth=RegistryCredentials \
+    --registry-credentials="$REGISTRY_USER:$REGISTRY_PASSWORD" \
     --container-image=$CONTAINER_IMAGE_FROM_PRIVATE_REGISTRY
 ```
 

--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -59,6 +59,7 @@ Flag                | Required | Default | Description
 *--zone*            | Yes      | nil     | Zone where the resources will be used to create the image creator resources
 *--gcs-path*        | No       | nil     | GCS path prefix to dump the logs and upload the startup script. If omitted, a `<project>-daisy-bkt` bucket is auto-created (or reused) in the project.
 *--container-image* | Yes      | nil     | Container image with tag to include in the disk image. Tag are required for image like `latest` in this example: `docker.io/library/python:latest`. This flag can be specified multiple times
+*--container-image-file* | No  | nil     | Path to a file listing container images to include in the disk image, one image per line. Blank lines and lines starting with `#` are ignored. Pass `/dev/stdin` to read from standard input. Images from this file are added to any specified via *--container-image*.
 *--gcp-oauth*       | No       | nil     | Path to GCP service account credential file
 *--disk-size-gb*    | No       | 10      | Size of a disk that will host the unpacked images
 *--image-pull-auth* | No       | 'None'  | Auth mechanism to pull the container image, valid values: [None, ServiceAccountToken, RegistryCredentials]. None means that the images are publically available and no authentication is required to pull them. ServiceAccountToken means the service account oauth token will be used to pull the images. RegistryCredentials means the `user:password` string provided via *--registry-credentials* will be used to pull the images. For more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications
@@ -181,6 +182,38 @@ go run ./cli \
     --gcs-path=gs://$GCS_PATH/ \
     --container-image=docker.io/library/python:latest \
     --container-image=docker.io/library/nginx:latest
+```
+
+### Pull a list of images from a file
+
+Instead of repeating `--container-image`, you can list the images in a file, one
+per line. Blank lines and lines starting with `#` are ignored, and the images
+are added to any passed via `--container-image`.
+
+```shell
+cat > images.txt <<EOF
+# core services
+docker.io/library/python:latest
+docker.io/library/nginx:latest
+EOF
+
+go run ./cli \
+    --project-name=$PROJECT_NAME \
+    --image-name=$IMAGE_NAME \
+    --zone=$ZONE \
+    --gcs-path=gs://$GCS_PATH/ \
+    --container-image-file=images.txt
+```
+
+Per Unix convention, pass `/dev/stdin` to read the list from standard input:
+
+```shell
+generate-image-list | go run ./cli \
+    --project-name=$PROJECT_NAME \
+    --image-name=$IMAGE_NAME \
+    --zone=$ZONE \
+    --gcs-path=gs://$GCS_PATH/ \
+    --container-image-file=/dev/stdin
 ```
 
 ### Pull a large image from a public registry

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
@@ -69,6 +70,7 @@ func main() {
 	verifyOnly := flag.Bool("verify-only", false, "Only verifies the disk image provided in image-name, and does not generate any image.")
 	k8sManifestsFilepath := flag.String("k8s-manifests-filepath", "", "Specifies the file path where the tool will save the generated Kubernetes VolumeSnapshot and VolumeSnapshotContent manifests.")
 	k8sNamespace := flag.String("k8s-namespace", "default", "Specifies the Kubernetes namespace for the generated VolumeSnapshot manifest.")
+	containerImageFile := flag.String("container-image-file", "", "path to a file listing container images to include in the disk image, one image per line. Blank lines and lines starting with `#` are ignored. Pass `/dev/stdin` to read from standard input. Images from this file are added to any specified via --container-image.")
 
 	flag.Var(&imageLabels, "image-labels", "labels tagged to the disk image. This flag can be specified multiple times. The accepted format is `--image-labels=key=val`.")
 	flag.Var(&containerImages, "container-image", "container image to include in the disk image. This flag can be specified multiple times")
@@ -76,6 +78,14 @@ func main() {
 
 	flag.Parse()
 	ctx := context.Background()
+
+	if *containerImageFile != "" {
+		imagesFromFile, err := readContainerImageFile(*containerImageFile)
+		if err != nil {
+			log.Panicf("invalid argument, container-image-file: %v", err)
+		}
+		containerImages = append(containerImages, imagesFromFile...)
+	}
 
 	td, err := time.ParseDuration(*timeout)
 	if err != nil {
@@ -179,6 +189,32 @@ func main() {
 		}
 		fmt.Printf("Kubernetes manifests generated at: %s\n", req.K8sManifestsFilepath)
 	}
+}
+
+// readContainerImageFile reads container image references from the file at the
+// given path, one image per line. Surrounding whitespace is trimmed; blank lines
+// and lines starting with `#` (comments) are ignored. Passing "/dev/stdin" reads
+// from standard input, per Unix convention.
+func readContainerImageFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var images []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		images = append(images, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return images, nil
 }
 
 // regionForZone returns the region for a given zone (e.g. "us-central1-c" -> "us-central1").

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -54,13 +54,14 @@ func main() {
 	imageFamilyName := flag.String("image-family-name", "secondary-disk-image", "name of the image family associated with the created disk image")
 	jobName := flag.String("job-name", "secondary-disk-image", "name of the workflow job; no more than 50 characters")
 	zone := flag.String("zone", "", "zone where the resources will be used to create the image creator resources")
-	gcsPath := flag.String("gcs-path", "", "gcs location to dump the logs")
+	gcsPath := flag.String("gcs-path", "", "gcs location to dump the logs and upload the startup script. Optional: if left empty, a `<project>-daisy-bkt` bucket is auto-created/reused in the project.")
 	machineType := flag.String("machine-type", "n2-standard-16", "GCE instance machine type to generate the disk image")
 	serviceAccount := flag.String("service-account", "default", "Service Account email assigned to the GCE instance used for creating the disk image.")
 	diskType := flag.String("disk-type", "pd-ssd", "disk type to generate the disk image")
 	diskSizeGb := flag.Int64("disk-size-gb", 60, "disk size to unpack container images")
 	gcpOAuth := flag.String("gcp-oauth", "", "path to GCP service account credential file")
-	imagePullAuth := flag.String("image-pull-auth", "None", "auth mechanism to pull the container image, valid values: [None, ServiceAccountToken].\nNone means that the images are publically available and no authentication is required to pull them.\nServiceAccountToken means the service account oauth token will be used to pull the images.\nFor more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications")
+	imagePullAuth := flag.String("image-pull-auth", "None", "auth mechanism to pull the container image, valid values: [None, ServiceAccountToken, RegistryCredentials].\nNone means that the images are publically available and no authentication is required to pull them.\nServiceAccountToken means the service account oauth token will be used to pull the images.\nRegistryCredentials means the user:password string provided via --registry-credentials will be used to pull the images.\nFor more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications")
+	registryCredentials := flag.String("registry-credentials", "", "user:password credential passed to `ctr image pull --user` when --image-pull-auth=RegistryCredentials.\nThis value is embedded in the startup script uploaded to --gcs-path, so restrict access to that bucket.")
 	timeout := flag.String("timeout", "20m", "Default timout for each step, defaults to 20m")
 	network := flag.String("network", "default", "VPC network to be used by GCE resources used for disk image creation.")
 	subnet := flag.String("subnet", "default", "subnet to be used by GCE resources used for disk image creation.")
@@ -121,8 +122,17 @@ func main() {
 		auth = builder.None
 	case "ServiceAccountToken":
 		auth = builder.ServiceAccountToken
+	case "RegistryCredentials":
+		auth = builder.RegistryCredentials
 	default:
-		log.Panicf("Please specify a valid value for the flag --image-pull-auth, valid values are [None, ServiceAccountToken]")
+		log.Panicf("Please specify a valid value for the flag --image-pull-auth, valid values are [None, ServiceAccountToken, RegistryCredentials]")
+	}
+
+	if auth == builder.RegistryCredentials && *registryCredentials == "" {
+		log.Panicf("--registry-credentials must be set to a user:password string when --image-pull-auth=RegistryCredentials")
+	}
+	if *registryCredentials != "" && auth != builder.RegistryCredentials {
+		log.Panicf("--registry-credentials is only valid with --image-pull-auth=RegistryCredentials")
 	}
 
 	req := builder.Request{
@@ -143,6 +153,7 @@ func main() {
 		StorageLocations:      storageLocations,
 		Timeout:               td,
 		ImagePullAuth:         auth,
+		RegistryCredentials:   *registryCredentials,
 		ImageLabels:           imageLabels,
 		StoreSnapshotCheckSum: *storeSnapshotCheckSum,
 		K8sManifestsFilepath:  *k8sManifestsFilepath,

--- a/gke-disk-image-builder/cli/main_test.go
+++ b/gke-disk-image-builder/cli/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestReadContainerImageFile(t *testing.T) {
+	content := "# core services\ndocker.io/library/python:latest\n\n  docker.io/library/nginx:latest  \n\t# trailing comment\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "images.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readContainerImageFile(path)
+	if err != nil {
+		t.Fatalf("readContainerImageFile failed: %v", err)
+	}
+
+	want := []string{
+		"docker.io/library/python:latest",
+		"docker.io/library/nginx:latest",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("readContainerImageFile() = %v, want %v", got, want)
+	}
+}
+
+func TestReadContainerImageFile_Missing(t *testing.T) {
+	if _, err := readContainerImageFile(filepath.Join(t.TempDir(), "nope.txt")); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -44,6 +44,11 @@ const (
 	// ServiceAccountToken means that the script must use the oauth access token of the service account.
 	// For more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications
 	ServiceAccountToken ImagePullAuthMechanism = "ServiceAccountToken"
+	// RegistryCredentials means the script will pull images using a static
+	// user:password credential supplied via Request.RegistryCredentials, passed
+	// to `ctr image pull --user`. Use this for private registries that do not
+	// accept a GCP service account OAuth token (e.g. Docker Hub, Quay, Harbor).
+	RegistryCredentials ImagePullAuthMechanism = "RegistryCredentials"
 )
 
 // Request contains the required input for the disk image generation.
@@ -64,6 +69,9 @@ type Request struct {
 	StorageLocations      []string
 	Timeout               time.Duration
 	ImagePullAuth         ImagePullAuthMechanism
+	// RegistryCredentials is a user:password string passed to `ctr image pull --user`.
+	// It is only used when ImagePullAuth == RegistryCredentials.
+	RegistryCredentials string
 	ImageLabels           []string
 	ServiceAccount        string
 	StoreSnapshotCheckSum bool
@@ -114,6 +122,12 @@ spec:
 	return os.WriteFile(req.K8sManifestsFilepath, []byte(manifest), 0644)
 }
 
+// bashSingleQuote wraps s in single quotes, escaping any embedded single quotes,
+// so it is safe to embed as a literal in the generated startup script.
+func bashSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 func buildDiskStartupScript(req Request) (*os.File, error) {
 	concreteStartupScript, err := os.CreateTemp("", fmt.Sprintf("%s-startup-script-", req.JobName))
 	if err != nil {
@@ -128,7 +142,12 @@ func buildDiskStartupScript(req Request) (*os.File, error) {
 		return nil, fmt.Errorf("unable to create the concrete startup file suceesfully, err: %v", err)
 	}
 	images := strings.Join(req.ContainerImages, " ")
-	flags := fmt.Sprintf("\n\nunpack %t %s %s", req.StoreSnapshotCheckSum, req.ImagePullAuth, images)
+	// Expose the (optional) registry credential as a shell global the startup
+	// script's pull_images function reads. It is emitted unconditionally (empty
+	// when unused) so the positional contract of the unpack call below is
+	// unaffected by the variable-length image list.
+	creds := fmt.Sprintf("\nREGISTRY_CREDENTIALS=%s", bashSingleQuote(req.RegistryCredentials))
+	flags := fmt.Sprintf("%s\n\nunpack %t %s %s", creds, req.StoreSnapshotCheckSum, req.ImagePullAuth, images)
 	if _, err = concreteStartupScript.Write([]byte(flags)); err != nil {
 		return nil, fmt.Errorf("umable to create concrete startup script: %v", err)
 	}

--- a/gke-disk-image-builder/imager_test.go
+++ b/gke-disk-image-builder/imager_test.go
@@ -61,6 +61,23 @@ spec:
 	}
 }
 
+func TestBashSingleQuote(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "''"},
+		{"user:password", "'user:password'"},
+		{"user:p@ss word", "'user:p@ss word'"},
+		{"a'b", `'a'\''b'`},
+	}
+	for _, c := range cases {
+		if got := bashSingleQuote(c.in); got != c.want {
+			t.Errorf("bashSingleQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestWriteK8sManifests_ParentDirDoesNotExist(t *testing.T) {
 	req := Request{
 		ImageName:            "test-image",

--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -87,8 +87,13 @@ function pull_images() {
       sudo ctr -n k8s.io image pull --hosts-dir "/etc/containerd/certs.d" $param
     elif [ "$OAUTH_MECHANISM" == "serviceaccounttoken" ]; then
       sudo ctr -n k8s.io image pull --hosts-dir "/etc/containerd/certs.d" --user "oauth2accesstoken:$ACCESS_TOKEN" $param
+    elif [ "$OAUTH_MECHANISM" == "registrycredentials" ]; then
+      # Pull using a static user:password credential provided by the caller.
+      # REGISTRY_CREDENTIALS is set as a global at the top of the generated
+      # startup script; do not echo it.
+      sudo ctr -n k8s.io image pull --hosts-dir "/etc/containerd/certs.d" --user "$REGISTRY_CREDENTIALS" $param
     else
-      echo "Unknown OAuth mechanism, expected 'None' or 'ServiceAccountToken' but got '$OAUTH_MECHANISM'".
+      echo "Unknown OAuth mechanism, expected 'None', 'ServiceAccountToken' or 'RegistryCredentials' but got '$OAUTH_MECHANISM'".
       exit 1
     fi
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Using this tool at my job, I've add to add some things to allow reading from our private DockerHub registry. Also, as we have 22+ images, listing options was laborious so I added a list file option that can be used for easier operation.